### PR TITLE
fix: ensure overflow-y is set to auto for filterbar

### DIFF
--- a/src/assets/css/_filterbar.scss
+++ b/src/assets/css/_filterbar.scss
@@ -9,6 +9,8 @@
     z-index: 11;
     background-color: colors.$color-background;
 
+    overflow-y: auto;
+
     @media screen and (max-width: 500px) {
         width: 250px;
     }


### PR DESCRIPTION
## Description
This PR adds `overflow-y: auto` to the `filterbar` component to enable vertical scrolling when the content exceeds the height of the viewport.

## Why this change?  
This ensures that the `filterbar` remains usable on smaller screens or when there is a large amount of content.