### PR TITLE
feat: improve homepage metadata and handle missing person data

### DIFF
--- a/src/components/LogoHeader.svelte
+++ b/src/components/LogoHeader.svelte
@@ -1,10 +1,16 @@
 <div class="logo-header">
 	<div class="logo-header__container">
-		<img src="/svelma.svg" alt="" />
+		<a href="/">
+			<img src="/svelma.svg" alt="" />
+		</a>
 	</div>
 </div>
 
 <style>
+	a {
+		display: inline-block;
+		line-height: 0;
+	}
 	img {
 		width: 195px;
 		height: 78px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,6 +59,10 @@
 
 </script>
 
+<svelte:head>
+    <title>Svelma</title>
+</svelte:head>
+
 <div class="container">
 	<div class="header">
 		<div class="header__logo">

--- a/src/routes/personnes/[id]/+page.svelte
+++ b/src/routes/personnes/[id]/+page.svelte
@@ -11,6 +11,7 @@
     let biographyParagraphs = person.biography ? person.biography.split('\n\n') : [];
 
     function formatDate(dateString) {
+		if (!dateString) return "Date inconnue";
         const date = new Date(dateString);
         return new Intl.DateTimeFormat('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' }).format(date);
     }
@@ -58,7 +59,7 @@
 					<div class="actor-details__personalinfo-item">
 						<div class="actor-details__personalinfo-item-title">Lieu de naissance</div>
 						<div class="actor-details__personalinfo-item-value">
-							{person.place_of_birth}
+							{person.place_of_birth ?? "Lieu inconnu"}
 						</div>
 					</div>
 
@@ -69,7 +70,7 @@
 
 					<div class="actor-details__personalinfo-item">
 						<div class="actor-details__personalinfo-item-title">Célèbre pour</div>
-						<div class="actor-details__personalinfo-item-value">Acting</div>
+						<div class="actor-details__personalinfo-item-value">{person.known_for_department ?? "??"}</div>
 					</div>
 				</div>
 			</div>
@@ -84,6 +85,8 @@
 				<div class="actor-details__biography-text">
                     {#each biographyParagraphs as paragraph, index}
                         <p style="margin-top: {index === 0 ? '0' : ''}">{paragraph}</p>
+					{:else}
+						<p style="margin-top: 0">Aucune biographie disponible.</p>
                     {/each}
 				</div>
 			</div>


### PR DESCRIPTION
## Description
This PR adds a missing `<title>` to the homepage, makes the logo clickable for better navigation, and handles missing biography, birthplace, or department data gracefully.

## Why this change?
To improve accessibility, user experience, and ensure stability when some person data is unavailable.