### PR TITLE
refactor: move SCSS imports into corresponding Svelte components

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,19 +1,10 @@
 
 @use './assets/css/reset';
 @use './assets/css/container';
-@use './assets/css/movie-card';
-@use './assets/css/pagination';
 @use './assets/css/header';
-@use './assets/css/searchbar';
-@use './assets/css/filter';
 
 @use './assets/css/banner';
-@use './assets/css/movie-details';
 @use './assets/css/actors';
-@use "./assets/css/filterbar";
-@use './assets/css/mask';
-@use './assets/css/actor';
-@use './assets/css/navbar';
 @use './assets/css/logo-header';
 
 @use './assets/css/theme';

--- a/src/components/Filter.svelte
+++ b/src/components/Filter.svelte
@@ -1,4 +1,5 @@
 <script>
+    import '../assets/css/_filter.scss';
     const { onToggleFilters } = $props();
 </script>
 

--- a/src/components/FilterBar.svelte
+++ b/src/components/FilterBar.svelte
@@ -1,4 +1,5 @@
 <script>
+	import '../assets/css/_filterbar.scss';
 	import { onMount } from "svelte";
 
 	const currentYear = new Date().getFullYear();

--- a/src/components/Mask.svelte
+++ b/src/components/Mask.svelte
@@ -1,4 +1,5 @@
 <script>
+	import '../assets/css/_mask.scss';
 	const { onClick } = $props();
 </script>
 

--- a/src/components/MovieCard.svelte
+++ b/src/components/MovieCard.svelte
@@ -1,4 +1,5 @@
 <script>
+    import "../assets/css/_movie-card.scss";
     let { id, title, year, vote_average, poster_path } = $props();
 
     let formattedVoteAverage =

--- a/src/components/MovieDetails.svelte
+++ b/src/components/MovieDetails.svelte
@@ -1,4 +1,5 @@
 <script>
+    import "../assets/css/_movie-details.scss";
     let { original_title, genres, vote_average, vote_count, poster_path, release_date, runtime, overview } = $props();
 
     let formattedVoteAverage = vote_average.toLocaleString('fr-FR', { minimumFractionDigits: 1, maximumFractionDigits: 1 });

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -1,4 +1,5 @@
 <script>
+  import '../assets/css/_navbar.scss';
   import { theme } from '$lib/stores/theme';
   import { onMount, tick } from 'svelte';
   import { goto } from '$app/navigation';

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,4 +1,5 @@
 <script>
+    import "../assets/css/_pagination.scss";
 	import { createEventDispatcher } from "svelte";
 
     let { currentPage = 1, totalPages = 1 } = $props();

--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -1,4 +1,5 @@
 <script>
+    import '../assets/css/_searchbar.scss';
 	import { searchMovies } from "$lib/api/tmdb";
     import { createEventDispatcher, onDestroy } from "svelte";
     import { shouldFocusSearch } from "$lib/stores/focusSearch";

--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -49,7 +49,7 @@
         onkeydown={(e) => e.key === "Enter" && handleSearch()}
     />
     
-    <button type="button" aria-label="Lancer la recherche" onclick={handleSearch}>
+    <button type="button" aria-label="Lancer la recherche" onclick={() => handleSearch()}>
          <svg 
             width="20" 
             height="20" 

--- a/src/routes/personnes/[id]/+page.svelte
+++ b/src/routes/personnes/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import '../../../assets/css/_actor.scss';
 	import LogoHeader from '../../../components/LogoHeader.svelte';
     import MovieCard from '../../../components/MovieCard.svelte';
 	import Pagination from '../../../components/Pagination.svelte';


### PR DESCRIPTION
## Description
This PR moves SCSS imports into their corresponding Svelte components for improved optimization and better encapsulation of styles. 

This change helps ensure that only the necessary styles are loaded with each component, reducing unused CSS and improving maintainability.