### PR TITLE
fix: ensure flex-wrap is applied to movie types

### DIFF
--- a/src/assets/css/_movie-details.scss
+++ b/src/assets/css/_movie-details.scss
@@ -48,6 +48,7 @@ $responsive-breakpoint: 768px;
         &-types {
             display: flex;
             align-items: center;
+            flex-wrap: wrap;
             gap: 8px;
 
             margin-bottom: 1rem;


### PR DESCRIPTION
## Description  
This PR applies `flex-wrap` to the movie types to improve their responsiveness. 

Previously, the types would overflow on smaller screens.
